### PR TITLE
#38 tab usage in text area

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -161,6 +161,16 @@
         renderPreview()
     });
 
+    byId('code').addEventListener('keydown', (e) => {
+        if (e.key === "Tab" && e.shiftKey) {
+            e.preventDefault();
+            const { selectionStart, selectionEnd, value } = e.target;
+            const newValue = value.substring(0, selectionStart) + '    ' + value.substring(selectionEnd);
+            const newCursorPosition = selectionStart + 4;
+            e.target.value = newValue;
+            e.target.setSelectionRange(newCursorPosition, newCursorPosition);
+        }
+    });
 
     function applyChanges(lastCorrectCode, theme, base64, width, height) {
         console.log(lastCorrectCode, base64);

--- a/src/index.html
+++ b/src/index.html
@@ -162,7 +162,7 @@
     });
 
     byId('code').addEventListener('keydown', (e) => {
-        if (e.key === "Tab" && e.shiftKey) {
+        if (e.key === "Tab") {
             e.preventDefault();
             const { selectionStart, selectionEnd, value } = e.target;
             const newValue = value.substring(0, selectionStart) + '    ' + value.substring(selectionEnd);

--- a/src/index.html
+++ b/src/index.html
@@ -123,11 +123,11 @@
     }, 100);
 
     const defaultContent = `graph LR
-      A[Hard edge] -->|Link text| B(Round edge)
-      B --> C{Decision}
-      C -->|One| D[Result one]
-      C -->|Two| E[Result two]
-  `;
+    A[Hard edge] -->|Link text| B(Round edge)
+    B --> C{Decision}
+    C -->|One| D[Result one]
+    C -->|Two| E[Result two]
+`;
 
     function setCode(source) {
         byId('code').value = source || defaultContent;


### PR DESCRIPTION
addressing #38.
The current implementation just replaces the form navigation tab with the ability to tab inside the text area.
Tabs are 4 spaces, as they should be ;)

Also, changed the default content to have 4 spaces instead of 6 + removed 2 spaces at the start of the new line

<a href="https://gyazo.com/864a462300bbea19ecba97a997b9fcfc"><img src="https://i.gyazo.com/864a462300bbea19ecba97a997b9fcfc.gif" alt="Image from Gyazo" width="464"/></a>
